### PR TITLE
ANSI to UTF8 conversion

### DIFF
--- a/app/controllers/importer_controller.rb
+++ b/app/controllers/importer_controller.rb
@@ -1,5 +1,6 @@
 require 'fastercsv'
 require 'tempfile'
+require 'iconv'
 
 class MultipleIssuesForUniqueValue < Exception
 end
@@ -41,6 +42,12 @@ class ImporterController < ApplicationController
     sample_count = 5
     i = 0
     @samples = []
+    
+    # transcode the ANSI format using iconv
+    if (iip.encoding == "A" )
+    	ansi2utf8(iip)
+    end
+    
     
     FasterCSV.new(iip.csv_data, {:headers=>true,
     :encoding=>iip.encoding, :quote_char=>iip.quote_char, :col_sep=>iip.col_sep}).each do |row|
@@ -362,6 +369,14 @@ class ImporterController < ApplicationController
   end
 
 private
+	
+	# converts the ImportInProgrsse csv data from ansi to utf8
+  def ansi2utf8(importip)
+    converter = Iconv.new('UTF-8','CP1252')
+    importip.csv_data=converter.iconv(importip.csv_data)
+    #changing the encoding tag : U for UTF8
+    importip.encoding = "U"
+  end
 
   def find_project
     @project = Project.find(params[:project_id])

--- a/app/controllers/importer_controller.rb
+++ b/app/controllers/importer_controller.rb
@@ -45,8 +45,12 @@ class ImporterController < ApplicationController
     
     # transcode the ANSI format to UTF8 using iconv
     if (iip.encoding == "A" )
-    	ansi2utf8(iip)
+    	ansi2utf8!(iip)
     end
+    
+    # preparing the import
+    chomp_separators!(iip)
+    sub_blanks!(iip)
 
     FasterCSV.new(iip.csv_data, {:headers=>true,
     :encoding=>iip.encoding, :quote_char=>iip.quote_char, :col_sep=>iip.col_sep}).each do |row|
@@ -169,8 +173,12 @@ class ImporterController < ApplicationController
 		
     # transcode the ANSI format to UTF8 using iconv
     if (iip.encoding == "A" )
-    	ansi2utf8(iip)
+    	ansi2utf8!(iip)
     end
+    
+    # preparing the import
+    chomp_separators!(iip)
+    sub_blanks!(iip)
 
     FasterCSV.new(iip.csv_data, {:headers=>true, :encoding=>iip.encoding, 
         :quote_char=>iip.quote_char, :col_sep=>iip.col_sep}).each do |row|
@@ -377,12 +385,42 @@ class ImporterController < ApplicationController
 private
 	
 	# converts the ImportInProgrsse csv data from ansi to utf8
-	def ansi2utf8(importip)
+	# @param ImportInProgress importip, the ImportInProgress to be transcoded from ANSI to UTF8
+	def ansi2utf8!(importip)
 		converter = Iconv.new('UTF-8','CP1252')
 		importip.csv_data = converter.iconv(importip.csv_data)
 		#changing the encoding tag : U for UTF8
 		importip.encoding = "U"
 	end
+	
+	
+  # deletes a repetition of CSV separators at the end of the file (eg. "last_field,,,\n" becomes "last_field\n")
+  # @param ImportInProgress importip whose csv_data will be processed
+	def chomp_separators!(importip)
+		separator=importip.col_sep
+		csv_data_chomped=""
+		importip.csv_data.each_line{ |line|
+			line.chomp!
+			line=~/^ *(.*?)((#{separator})*)$/
+			csv_data_chomped+=$1+"\n"
+		}
+		importip.csv_data=csv_data_chomped
+  end
+
+	#deletes spaces around separators and  in the start of line in csv_data (prevents parsing failure)
+	# @param ImportInProgress importip whose csv_data will be cleaned from unwanted spaces
+	def sub_blanks!(importip)
+		separator=importip.col_sep
+		csv_data_subed=""
+		importip.csv_data.each_line{ |line|
+			subed_line=line.gsub(/ *#{separator} */,separator)
+			csv_data_subed += subed_line
+		}
+		importip.csv_data=csv_data_subed
+		
+	end
+	
+
 
   def find_project
     @project = Project.find(params[:project_id])

--- a/app/views/importer/index.html.erb
+++ b/app/views/importer/index.html.erb
@@ -8,10 +8,10 @@
 
 	<fieldset class="box"><legend><%= l(:label_upload_format) %></legend>
 		 <p><label><%=l(:label_upload_encoding)%></label>
-		<%= select_tag "encoding", "<option value=\"U\">UTF8</option><option value=\"EUC\">EUC</option><option value=\"S\">SJIS</option><option value=\"N\">None</option>" %></p>
+		<%= select_tag "encoding", "<option value=\"A\">ANSI</option><option value=\"U\">UTF8</option><option value=\"EUC\">EUC</option><option value=\"S\">SJIS</option><option value=\"N\">None</option>" %></p>
 		
 		<p><label><%=l(:label_upload_splitter)%></label>
-		<%= text_field_tag "splitter", ',', {:size => 3, :maxlength => 1}%></p>
+		<%= text_field_tag "splitter", ';', {:size => 3, :maxlength => 1}%></p>
 		
 		<p><label><%=l(:label_upload_wrapper)%></label>
 		<%= text_field_tag "wrapper", '"', {:size => 3, :maxlength => 1}%></p>

--- a/app/views/importer/index.html.erb
+++ b/app/views/importer/index.html.erb
@@ -11,7 +11,7 @@
 		<%= select_tag "encoding", "<option value=\"A\">ANSI</option><option value=\"U\">UTF8</option><option value=\"EUC\">EUC</option><option value=\"S\">SJIS</option><option value=\"N\">None</option>" %></p>
 		
 		<p><label><%=l(:label_upload_splitter)%></label>
-		<%= text_field_tag "splitter", ';', {:size => 3, :maxlength => 1}%></p>
+		<%= text_field_tag "splitter", ',', {:size => 3, :maxlength => 1}%></p>
 		
 		<p><label><%=l(:label_upload_wrapper)%></label>
 		<%= text_field_tag "wrapper", '"', {:size => 3, :maxlength => 1}%></p>

--- a/test/ansi2utf8/ansi_accent.csv
+++ b/test/ansi2utf8/ansi_accent.csv
@@ -1,0 +1,2 @@
+Subject;Description;Assigned to
+tâche 1;créer objet;admin

--- a/test/ansi2utf8/ansi_noaccent.csv
+++ b/test/ansi2utf8/ansi_noaccent.csv
@@ -1,0 +1,2 @@
+Subject;Description;Assigned to
+tache 1;creer objet;admin

--- a/test/ansi2utf8/utf8-wBOM_accent.csv
+++ b/test/ansi2utf8/utf8-wBOM_accent.csv
@@ -1,0 +1,2 @@
+﻿Subject;Description;Assigned to
+tâche 1;créer objet;admin

--- a/test/ansi2utf8/utf8-wBOM_noaccent.csv
+++ b/test/ansi2utf8/utf8-wBOM_noaccent.csv
@@ -1,0 +1,2 @@
+﻿Subject;Description;Assigned to
+tache 1;creer objet;admin

--- a/test/ansi2utf8/utf8_accent.csv
+++ b/test/ansi2utf8/utf8_accent.csv
@@ -1,0 +1,2 @@
+Subject;Description;Assigned to
+tâche 1;créer objet;admin

--- a/test/ansi2utf8/utf8_accent.csv
+++ b/test/ansi2utf8/utf8_accent.csv
@@ -1,0 +1,2 @@
+﻿Subject;Description;Assigned to
+tâche 1;créer objet;admin

--- a/test/ansi2utf8/utf8_noaccent.csv
+++ b/test/ansi2utf8/utf8_noaccent.csv
@@ -1,0 +1,2 @@
+﻿Subject;Description;Assigned to
+tache 1;creer objet;admin

--- a/test/ansi2utf8/utf8_noaccent.csv
+++ b/test/ansi2utf8/utf8_noaccent.csv
@@ -1,0 +1,2 @@
+Subject;Description;Assigned to
+tache 1;creer objet;admin


### PR DESCRIPTION
I've added support for CSV files encoded in ANSI.
Importing ANSI files in UTF8 mode into redmine replaces accents like é,à or è by some unrecognized character.
I've implemented transcoding ANSI into UTF8 before parsing (FasterCSV does not parse ANSI files). This uses 'iconv' from ruby standard library.

This is convenient for windows users. Feel free to ask for questions or give some feedback. 
thank you !
