### PR TITLE
Fix encoding error.

### DIFF
--- a/app/helpers/importer_helper.rb
+++ b/app/helpers/importer_helper.rb
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+require "nkf"
+
+module ImporterHelper
+  ENCODINGS_FOR_SELECT = [ [ "UTF8", "U" ], [ "EUC", "EUC" ], [ "SJIS", "S" ], [ "None", "N" ] ]
+  ENCODING_CONVERTER = {
+    "U"   => nil,  # Need not to convert
+    "EUC" => Proc.new{ |str| NKF.nkf("-Ewm0", str) },
+    "S"   => Proc.new{ |str| NKF.nkf("-Swm0", str) },
+    "N"   => nil  # Need not to convert
+  }
+
+  def importer_encodings_for_select
+    return ENCODINGS_FOR_SELECT
+  end
+
+  def importer_encoding_converter(enc_param)
+    return ENCODING_CONVERTER[enc_param]
+  end
+end
+

--- a/app/views/importer/index.html.erb
+++ b/app/views/importer/index.html.erb
@@ -8,7 +8,7 @@
 
 	<fieldset class="box"><legend><%= l(:label_upload_format) %></legend>
 		 <p><label><%=l(:label_upload_encoding)%></label>
-		<%= select_tag "encoding", "<option value=\"U\">UTF8</option><option value=\"EUC\">EUC</option><option value=\"S\">SJIS</option><option value=\"N\">None</option>" %></p>
+		<%= select_tag "encoding", options_for_select(importer_encodings_for_select) %></p>
 		
 		<p><label><%=l(:label_upload_splitter)%></label>
 		<%= text_field_tag "splitter", ',', {:size => 3, :maxlength => 1}%></p>


### PR DESCRIPTION
If EUC or SJIS file is uploaded, characters are corrupted in match.html.erb,
because Rails expects that characters are UTF-8.

I modified as follows:
- Convert file data to UTF-8 at the top of match method, and then store to iip.csv_data.
- Change FasterCSV encoding parameter to UTF-8 from iip.encoding.

If you have any questions, let me know please.

There are too many redmine_importer in GitHub...
I think that your plugin is the best of all!

Regards,
Murase
