### PR TITLE
Stop the generation of a parameter for the bytea datatype because postgresql (v9.1 at least, perhaps others) don't allow parameters. One might consider this a bug in the db abstraction layer and this is therefore a workaround rather than a fix.

### DIFF
--- a/db/migrate/001_create_import_in_progresses.rb
+++ b/db/migrate/001_create_import_in_progresses.rb
@@ -6,7 +6,7 @@ class CreateImportInProgresses < ActiveRecord::Migration
       t.string :col_sep, :limit => 8
       t.string :encoding, :limit => 64
       t.column :created, :datetime
-      t.column :csv_data, :binary, :limit => 4096*1024
+      t.column :csv_data, :binary
     end
   end
 


### PR DESCRIPTION
...esql (at least version 9.1) won't take parameters for it.
